### PR TITLE
📌Chore: codemagic.yaml 변수 그룹 지정

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -12,6 +12,8 @@ workflows:
 
     environment:
       flutter: stable
+      groups:
+        - android_release_signing
 
     scripts:
       - name: 🔐 Decode keystore


### PR DESCRIPTION
### 구현 배경
- codemagic 자동 빌드 오류
- 사유 : codemagic 내 변수들 그룹 미지정
### 작업 사항
- codemagic.yaml 변수 그룹 지정
### 추가 논의