### PR TITLE
Fix(IL-19): keystore 경로 오류 수정

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -17,7 +17,7 @@ workflows:
 
     scripts:
       - name: 🔐 Decode keystore
-        script: echo $CM_KEYSTORE | base64 --decode > $FCI_BUILD_DIR/keystore.jks
+        script: echo $CM_KEYSTORE | base64 --decode > android/app/keystore.jks
 
       - name: 📄 Generate key.properties
         script: |


### PR DESCRIPTION
### 구현 배경

- keystore 경로를 불러오지 못해 CI에 문제 발생 

### 작업 사항

- yaml 파일 내의 keystore 생성 경로 수정

### 추가 논의

- 추가적인 버그 수정 있을 수 있음.