### PR TITLE
메인화면 준비중인 여행, 메인여행 스케줄 카테고리 및 UI 구조 재수정

### DIFF
--- a/lib/common/component/setting_trip_card.dart
+++ b/lib/common/component/setting_trip_card.dart
@@ -74,15 +74,21 @@ class SettingTripCard extends StatelessWidget {
     }
   }
 
-  int _getDaysUntilTrip() {
-    if (startedAt == null) return 0;
+  String _getDaysUntilTrip() {
+    if (startedAt == null) return '-??';
     try {
       final startDate = DateTime.parse(startedAt!);
       final now = DateTime.now();
       final difference = startDate.difference(now).inDays;
-      return difference < 0 ? 0 : difference + 1;
+      if (difference < -1) {
+        return '+${(-difference - 1).toString()}'; // D+숫자
+      } else if (difference < 0) {
+        return '-0';
+      } else {
+        return '-${(difference + 1).toString()}'; // D-숫자
+      }
     } catch (_) {
-      return 0;
+      return '-??';
     }
   }
 
@@ -136,7 +142,7 @@ class SettingTripCard extends StatelessWidget {
                   child: Align(
                     alignment: Alignment.center,
                     child: Text(
-                      'D-$daysLeft',
+                      'D$daysLeft',
                       style: TextStyle(
                         fontSize: 14.sp,
                         color: Color(0xFF8287ff),

--- a/lib/schedule/component/schedule_item.dart
+++ b/lib/schedule/component/schedule_item.dart
@@ -157,12 +157,7 @@ class _ScheduleItemListState extends ConsumerState<ScheduleItemList>
         final emptyCollapsedHeight = 50.h; // "아직 예정된 일정이 없어요" 텍스트만 보이는 높이
         final emptyExpandedHeight = 100.h; // 텍스트 아래 빈공간이 더 보이는 높이
 
-        // 아이템이 있는 경우의 높이 설정
-        final collapsedHeight =
-            itemHeight * 1 + listBottomPadding; // 접힌 상태: 1개만
-        final expandedHeight =
-            itemHeight * 3.3 + listBottomPadding; // 펼친 상태: 3.3개
-
+        // 높이 계산 로직
         double calculatedHeight;
 
         if (totalItemCount == 0) {
@@ -171,7 +166,17 @@ class _ScheduleItemListState extends ConsumerState<ScheduleItemList>
               isExpanded ? emptyExpandedHeight : emptyCollapsedHeight;
         } else {
           // 아이템이 있는 경우
-          calculatedHeight = isExpanded ? expandedHeight : collapsedHeight;
+          if (isExpanded) {
+            // 펼친 상태: 모든 아이템을 보여줄 수 있는 높이
+            calculatedHeight =
+                itemHeight * totalItemCount + listBottomPadding + 10.h;
+          } else {
+            // 접은 상태: 최대 3.5개까지만 보이는 높이
+            final visibleItemCount =
+                totalItemCount > 3.3 ? 3.3 : totalItemCount.toDouble();
+            calculatedHeight =
+                itemHeight * visibleItemCount + listBottomPadding;
+          }
         }
 
         // 날짜 타이틀 로직
@@ -278,7 +283,8 @@ class _ScheduleItemListState extends ConsumerState<ScheduleItemList>
                                         ScheduleItem(
                                           title: place.name,
                                           category:
-                                              'TOURISM', // TODO: place에서 카테고리 가져오기
+                                              place
+                                                  .placeType, // TODO: place에서 카테고리 가져오기
                                           time: null,
                                           done: place.isVisited,
                                         ),
@@ -289,7 +295,8 @@ class _ScheduleItemListState extends ConsumerState<ScheduleItemList>
                                     return ScheduleItem(
                                       title: place.name,
                                       category:
-                                          'TOURISM', // TODO: place에서 카테고리 가져오기
+                                          place
+                                              .placeType, // TODO: place에서 카테고리 가져오기
                                       time: null,
                                       done: place.isVisited,
                                     );

--- a/lib/schedule/screen/naver_place_map_screen.dart
+++ b/lib/schedule/screen/naver_place_map_screen.dart
@@ -313,6 +313,22 @@ class _NaverPlaceMapScreenState extends ConsumerState<NaverPlaceMapScreen> {
               errorMsg = e.toString();
             }
           }
+          
+          // 성공 시 슬라이더바 내리기
+          if (success) {
+            setState(() {
+              _showSliderBar = false;
+            });
+            // 애니메이션 완료 후 선택된 장소도 초기화
+            Future.delayed(const Duration(milliseconds: 400), () {
+              if (mounted) {
+                setState(() {
+                  _selectedPlace = null;
+                });
+              }
+            });
+          }
+          
           // 수정: async gap 이후 context 사용 시 mounted 체크 추가
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/trip/component/detail_screen/schedule_dashboard/view/completed_schedule_view.dart
+++ b/lib/trip/component/detail_screen/schedule_dashboard/view/completed_schedule_view.dart
@@ -7,8 +7,6 @@ import 'package:yeogiga/schedule/component/schedule_item.dart';
 import 'package:yeogiga/schedule/provider/completed_schedule_provider.dart';
 import 'package:yeogiga/schedule/model/schedule_model.dart';
 import 'package:yeogiga/trip/component/detail_screen/schedule_dashboard/completed_trip_mini_map.dart';
-import 'package:yeogiga/trip/model/trip_model.dart';
-import 'package:yeogiga/trip/provider/trip_provider.dart';
 import 'package:yeogiga/trip/trip_map/end/end_trip_map.dart';
 
 class CompletedScheduleView extends StatelessWidget {
@@ -27,89 +25,100 @@ class CompletedScheduleView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer(
       builder: (context, ref, _) {
-        final completed = ref.watch(completedScheduleProvider).valueOrNull;
-        if (completed == null) {
-          // 최초 진입 시 state가 null이면 fetch를 한 번만 호출
-          final tripState = ref.read(tripProvider).valueOrNull;
-          if (tripState is TripModel) {
-            final tripId = tripState.tripId;
-            Future.microtask(() {
-              ref.read(completedScheduleProvider.notifier).fetch(tripId);
-            });
-          }
-          return const Center(child: CircularProgressIndicator());
-        }
-        final schedules = completed.data;
-        return CustomScrollView(
-          slivers: [
-            SliverToBoxAdapter(child: SizedBox(height: 12.h)),
-            //TODO: 날짜 선택기
-            SliverToBoxAdapter(
-              child: DaySelector(
-                itemCount: dynamicDays.length + 1, // +1 for 전체
-                selectedIndex: selectedDayIndex,
-                onChanged: onDaySelected,
-              ),
-            ),
-            SliverToBoxAdapter(child: SizedBox(height: 12.h)),
-            //TODO: 미니맵
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: EdgeInsets.symmetric(horizontal: 13.w),
-                child: CompletedTripMiniMap(
-                  dayPlaceModels:
-                      selectedDayIndex == 0
-                          ? schedules
-                          : schedules
-                              .where((s) => s.day == selectedDayIndex)
-                              .toList(),
-                  onTap: () async {
-                    GoRouter.of(context).pushNamed(EndTripMapScreen.routeName);
-                  },
+        final completedAsync = ref.watch(completedScheduleProvider);
+        return completedAsync.when(
+          data: (data) {
+            if (data == null) {
+              return const Center(
+                child: Text(
+                  '완료된 일정이 없습니다.',
+                  style: TextStyle(
+                    color: Colors.grey,
+                    fontSize: 16,
+                  ),
                 ),
-              ),
+              );
+            }
+            final schedules = data.data;
+            return CustomScrollView(
+              slivers: [
+                SliverToBoxAdapter(child: SizedBox(height: 12.h)),
+                //TODO: 날짜 선택기
+                SliverToBoxAdapter(
+                  child: DaySelector(
+                    itemCount: dynamicDays.length + 1, // +1 for 전체
+                    selectedIndex: selectedDayIndex,
+                    onChanged: onDaySelected,
+                  ),
+                ),
+                SliverToBoxAdapter(child: SizedBox(height: 12.h)),
+                //TODO: 미니맵
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 13.w),
+                    child: CompletedTripMiniMap(
+                      dayPlaceModels:
+                          selectedDayIndex == 0
+                              ? schedules
+                              : schedules
+                                  .where((s) => s.day == selectedDayIndex)
+                                  .toList(),
+                      onTap: () async {
+                        GoRouter.of(context).pushNamed(EndTripMapScreen.routeName);
+                      },
+                    ),
+                  ),
+                ),
+                SliverToBoxAdapter(child: SizedBox(height: 6.h)),
+                //TODO: 일정들
+                SliverList(
+                  delegate: SliverChildBuilderDelegate((context, index) {
+                    if (selectedDayIndex == 0) {
+                      // 전체 보기: 모든 Day
+                      final daySchedule = schedules.firstWhere(
+                        (s) => s.day == index + 1,
+                        orElse:
+                            () => CompletedTripDayPlaceModel(
+                              id: '',
+                              day: index + 1,
+                              places: [],
+                              unmatchedImage: null,
+                            ),
+                      );
+                      return _buildExpansionTile(daySchedule, 'Day ${index + 1}');
+                    } else {
+                      // 선택된 Day만 보기
+                      if (index == selectedDayIndex - 1) {
+                        final daySchedule = schedules.firstWhere(
+                          (s) => s.day == selectedDayIndex,
+                          orElse:
+                              () => CompletedTripDayPlaceModel(
+                                id: '',
+                                day: selectedDayIndex,
+                                places: [],
+                                unmatchedImage: null,
+                              ),
+                        );
+                        return _buildExpansionTile(
+                          daySchedule,
+                          'Day $selectedDayIndex',
+                        );
+                      } else {
+                        return const SizedBox.shrink();
+                      }
+                    }
+                  }, childCount: dynamicDays.length),
+                ),
+              ],
+            );
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, stackTrace) => Center(
+            child: Text(
+              '데이터를 불러오는데 실패했습니다: $error',
+              style: const TextStyle(color: Colors.red),
             ),
-            SliverToBoxAdapter(child: SizedBox(height: 6.h)),
-            //TODO: 일정들
-            SliverList(
-              delegate: SliverChildBuilderDelegate((context, index) {
-                if (selectedDayIndex == 0) {
-                  // 전체 보기: 모든 Day
-                  final daySchedule = schedules.firstWhere(
-                    (s) => s.day == index + 1,
-                    orElse:
-                        () => CompletedTripDayPlaceModel(
-                          id: '',
-                          day: index + 1,
-                          places: [],
-                          unmatchedImage: null,
-                        ),
-                  );
-                  return _buildExpansionTile(daySchedule, 'Day ${index + 1}');
-                } else {
-                  // 선택된 Day만 보기
-                  if (index == selectedDayIndex - 1) {
-                    final daySchedule = schedules.firstWhere(
-                      (s) => s.day == selectedDayIndex,
-                      orElse:
-                          () => CompletedTripDayPlaceModel(
-                            id: '',
-                            day: selectedDayIndex,
-                            places: [],
-                            unmatchedImage: null,
-                          ),
-                    );
-                    return _buildExpansionTile(
-                      daySchedule,
-                      'Day $selectedDayIndex',
-                    );
-                  } else {
-                    return const SizedBox.shrink();
-                  }
-                }
-              }, childCount: dynamicDays.length),
-            ),
-          ],
+          ),
         );
       },
     );

--- a/lib/trip_list/provider/trip_list_provider.dart
+++ b/lib/trip_list/provider/trip_list_provider.dart
@@ -13,7 +13,7 @@ final upcomingTripListProvider =
     );
 
 final allTripListProvider =
-    StateNotifierProvider<AllTripListNotifier, List<TripModel?>>(
+    StateNotifierProvider<AllTripListNotifier, AsyncValue<List<TripModel?>>>(
       (ref) => AllTripListNotifier(ref.read(tripListRepositoryProvider)),
     );
 
@@ -52,18 +52,23 @@ class UpcomingTripListNotifier extends StateNotifier<List<TripModel?>> {
   }
 }
 
-class AllTripListNotifier extends StateNotifier<List<TripModel?>> {
+class AllTripListNotifier extends StateNotifier<AsyncValue<List<TripModel?>>> {
   final TripListRepository repository;
 
-  AllTripListNotifier(this.repository) : super([]);
+  AllTripListNotifier(this.repository) : super(const AsyncValue.loading());
 
   Future<void> fetchAndSetAllTrips() async {
-    final trips = await repository.fetchAllTripList();
-    state = trips;
+    state = const AsyncValue.loading();
+    try {
+      final trips = await repository.fetchAllTripList();
+      state = AsyncValue.data(trips);
+    } catch (error, stackTrace) {
+      state = AsyncValue.error(error, stackTrace);
+    }
   }
 
   void clear() {
-    state = [];
+    state = const AsyncValue.data([]);
   }
 }
 

--- a/lib/user/view/my_page.dart
+++ b/lib/user/view/my_page.dart
@@ -63,30 +63,50 @@ class _MyPageState extends ConsumerState<MyPage> with RouteAware {
         Column(
           children: [
             SectionTitle("내 여행 모두 보기"),
-            PastTripCardList(
-              trips: ref.watch(allTripListProvider),
-              onTap: (tripId) async {
-                ref.invalidate(tripProvider); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
-                ref.invalidate(
-                  confirmScheduleProvider,
-                ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
-                ref.invalidate(
-                  pendingScheduleProvider,
-                ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
-                ref.invalidate(
-                  completedScheduleProvider,
-                ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
-                await ref.read(tripProvider.notifier).getTrip(tripId: tripId);
-                final tripState = ref.read(tripProvider).valueOrNull;
-                final userW2mState = ref.read(userW2mProvider);
-                if (context.mounted) {
-                  if (tripState is SettingTripModel &&
-                      userW2mState is NoUserW2mModel) {
-                    GoRouter.of(context).push('/dateRangePicker');
-                  } else {
-                    GoRouter.of(context).push('/tripDetailScreen');
-                  }
-                }
+            Consumer(
+              builder: (context, ref, _) {
+                final tripsAsync = ref.watch(allTripListProvider);
+                return tripsAsync.when(
+                  loading: () => SizedBox(
+                    height: 321.h,
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                  error: (e, _) => SizedBox(
+                    height: 321.h,
+                    child: Center(
+                      child: Text(
+                        '여행 목록을 불러올 수 없습니다.',
+                        style: TextStyle(fontSize: 14.sp, color: Colors.grey),
+                      ),
+                    ),
+                  ),
+                  data: (trips) => PastTripCardList(
+                    trips: trips,
+                    onTap: (tripId) async {
+                      ref.invalidate(tripProvider); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
+                      ref.invalidate(
+                        confirmScheduleProvider,
+                      ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
+                      ref.invalidate(
+                        pendingScheduleProvider,
+                      ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
+                      ref.invalidate(
+                        completedScheduleProvider,
+                      ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
+                      await ref.read(tripProvider.notifier).getTrip(tripId: tripId);
+                      final tripState = ref.read(tripProvider).valueOrNull;
+                      final userW2mState = ref.read(userW2mProvider);
+                      if (context.mounted) {
+                        if (tripState is SettingTripModel &&
+                            userW2mState is NoUserW2mModel) {
+                          GoRouter.of(context).push('/dateRangePicker');
+                        } else {
+                          GoRouter.of(context).push('/tripDetailScreen');
+                        }
+                      }
+                    },
+                  ),
+                );
               },
             ),
             SizedBox(height: 21.h),

--- a/lib/user/view/my_page_screen.dart
+++ b/lib/user/view/my_page_screen.dart
@@ -27,6 +27,14 @@ class MyPageScreen extends ConsumerStatefulWidget {
 
 class _MyWidgetState extends ConsumerState<MyPageScreen> {
   @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      ref.read(allTripListProvider.notifier).fetchAndSetAllTrips();
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final userState = ref.watch(userMeProvider);
 
@@ -134,31 +142,51 @@ class _MyWidgetState extends ConsumerState<MyPageScreen> {
             ),
 
             SizedBox(height: 12.h),
-            //TODO: 지난 여행 전체보기 슬라이드 뷰
-            PastTripCardList(
-              trips: ref.watch(allTripListProvider),
-              onTap: (tripId) async {
-                ref.invalidate(tripProvider); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
-                ref.invalidate(
-                  confirmScheduleProvider,
-                ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
-                ref.invalidate(
-                  pendingScheduleProvider,
-                ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
-                ref.invalidate(
-                  completedScheduleProvider,
-                ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
-                await ref.read(tripProvider.notifier).getTrip(tripId: tripId);
-                final tripState = ref.read(tripProvider).valueOrNull;
-                final userW2mState = ref.read(userW2mProvider);
-                if (context.mounted) {
-                  if (tripState is SettingTripModel &&
-                      userW2mState is NoUserW2mModel) {
-                    GoRouter.of(context).push('/dateRangePicker');
-                  } else {
-                    GoRouter.of(context).push('/tripDetailScreen');
-                  }
-                }
+            //TODO: 지간 여행 전체보기 슬라이드 뷰
+            Consumer(
+              builder: (context, ref, _) {
+                final tripsAsync = ref.watch(allTripListProvider);
+                return tripsAsync.when(
+                  loading: () => SizedBox(
+                    height: 321.h,
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                  error: (e, _) => SizedBox(
+                    height: 321.h,
+                    child: Center(
+                      child: Text(
+                        '여행 목록을 불러올 수 없습니다.',
+                        style: TextStyle(fontSize: 14.sp, color: Colors.grey),
+                      ),
+                    ),
+                  ),
+                  data: (trips) => PastTripCardList(
+                    trips: trips,
+                    onTap: (tripId) async {
+                      ref.invalidate(tripProvider); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
+                      ref.invalidate(
+                        confirmScheduleProvider,
+                      ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
+                      ref.invalidate(
+                        pendingScheduleProvider,
+                      ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
+                      ref.invalidate(
+                        completedScheduleProvider,
+                      ); // ← TODO: 진입 전 초기화 (앱 박살나는거 방지)
+                      await ref.read(tripProvider.notifier).getTrip(tripId: tripId);
+                      final tripState = ref.read(tripProvider).valueOrNull;
+                      final userW2mState = ref.read(userW2mProvider);
+                      if (context.mounted) {
+                        if (tripState is SettingTripModel &&
+                            userW2mState is NoUserW2mModel) {
+                          GoRouter.of(context).push('/dateRangePicker');
+                        } else {
+                          GoRouter.of(context).push('/tripDetailScreen');
+                        }
+                      }
+                    },
+                  ),
+                );
               },
             ),
             SizedBox(height: 20.h),


### PR DESCRIPTION
### 구현 배경

### 작업 사항

마이페이지 지난여행 전체보기 로드 문제 수정

목적지 삭제 시 schedule dashboard 전체 rebuild가 아닌, 참조 동등성 기반으로 구조 변경

목적지 선택 화면 UX개선(추가 시 자동으로 내려가게끔)

목적지 선택 화면 UI개선 (내 위치 버튼 slider바 위에 고정)

ing trip, end trip 화면 UI구조 개선(하단바 스크롤시, 마커들 rebuild 안되도록)

WidgetsBinding.instance.addPostFrameCallback 처리 수정 다수 (StateNotifierListenerError 방지)

### 추가 논의

ingtripmap에서 내 위치 버튼 집결지로 바꾸기
지도에 팀원위치 프로필 사진으로 띄워주기